### PR TITLE
Reduced code amount needed to calling toast

### DIFF
--- a/src/app/constants/app.constants.ts
+++ b/src/app/constants/app.constants.ts
@@ -1,5 +1,4 @@
 export namespace AppConstants {
   export const tokenStorageKey = 'token';
-  export const toastDuration = 3000;
   export const supportEmail = 'hubcollecti@gmail.com';
 }

--- a/src/app/interceptors/http-error/http-error.interceptor.spec.ts
+++ b/src/app/interceptors/http-error/http-error.interceptor.spec.ts
@@ -1,7 +1,7 @@
 import { HttpRequest } from '@angular/common/http';
 import { Provider } from '@angular/core';
-import { AppConstants } from '@constants/app.constants';
 import { runFnInContext } from '@ngx-unit-test/inject-mocks';
+import { ToastColor } from '@services/toast/toast.models';
 import { ToastService } from '@services/toast/toast.service';
 import { MockProxy, mock } from 'jest-mock-extended';
 import { of, take, throwError } from 'rxjs';
@@ -30,19 +30,11 @@ describe('httpErrorInterceptor', () => {
 
   it('should trigger "open$" method of toastService when error received', () => {
     const nextMock = jest.fn(() => throwError(() => errorMock));
-    const expectedConfig = {
-      duration: AppConstants.toastDuration,
-      cssClass: 'app-toast',
-      message: 'error',
-      position: 'bottom',
-      color: 'danger',
-      buttons: [{ icon: 'close-outline', role: 'cancel' }],
-    };
 
     const interceptor$ = runFnInContext(providers, () => httpErrorInterceptor({} as HttpRequest<unknown>, nextMock));
     interceptor$.pipe(take(1)).subscribe();
 
-    expect(toastServiceMock.open$).toHaveBeenCalledWith(expectedConfig);
+    expect(toastServiceMock.open$).toHaveBeenCalledWith('error', ToastColor.Danger);
   });
 
   it('should throw an error when error received during API call', () => {

--- a/src/app/interceptors/http-error/http-error.interceptor.ts
+++ b/src/app/interceptors/http-error/http-error.interceptor.ts
@@ -1,7 +1,6 @@
 import { HttpErrorResponse, HttpHandlerFn, HttpInterceptorFn, HttpRequest } from '@angular/common/http';
 import { inject } from '@angular/core';
-import { AppConstants } from '@constants/app.constants';
-import { ToastOptions } from '@ionic/angular/standalone';
+import { ToastColor } from '@services/toast/toast.models';
 import { ToastService } from '@services/toast/toast.service';
 import { catchError, switchMap, throwError } from 'rxjs';
 
@@ -10,16 +9,7 @@ export const httpErrorInterceptor: HttpInterceptorFn = (req: HttpRequest<unknown
 
   return next(req).pipe(
     catchError((error: HttpErrorResponse) => {
-      const toastOptions: ToastOptions = {
-        message: error.error.message,
-        duration: AppConstants.toastDuration,
-        cssClass: 'app-toast',
-        position: 'bottom',
-        color: 'danger',
-        buttons: [{ icon: 'close-outline', role: 'cancel' }],
-      };
-
-      return toastService.open$(toastOptions).pipe(switchMap(() => throwError(() => error)));
+      return toastService.open$(error.error.message, ToastColor.Danger).pipe(switchMap(() => throwError(() => error)));
     }),
   );
 };

--- a/src/app/pages/private/profile/change-password/change-password.page.spec.ts
+++ b/src/app/pages/private/profile/change-password/change-password.page.spec.ts
@@ -1,11 +1,11 @@
 import { ChangeDetectorRef } from '@angular/core';
 import { FormControl, FormGroup, NonNullableFormBuilder } from '@angular/forms';
-import { AppConstants } from '@constants/app.constants';
 import { UsersApiService } from '@features/users/services/users-api.service';
 import { GenericApiResponse } from '@models/api.models';
 import { TranslateService } from '@ngx-translate/core';
 import { classWithProviders } from '@ngx-unit-test/inject-mocks';
 import { LoaderService } from '@services/loader/loader.service';
+import { ToastColor } from '@services/toast/toast.models';
 import { ToastService } from '@services/toast/toast.service';
 import { MockProxy, mock } from 'jest-mock-extended';
 import { of } from 'rxjs';
@@ -140,18 +140,9 @@ describe(ChangePasswordPage.name, () => {
       });
 
       it('should open toast in case of success with correct config', () => {
-        const expectedToastConfig = {
-          message: 'change_password.toast',
-          duration: AppConstants.toastDuration,
-          cssClass: 'app-toast',
-          position: 'bottom',
-          color: 'success',
-          buttons: [{ icon: 'close-outline', role: 'cancel' }],
-        };
-
         component.changePassword();
 
-        expect(toastServiceMock.open$).toHaveBeenCalledWith(expectedToastConfig);
+        expect(toastServiceMock.open$).toHaveBeenCalledWith('change_password.toast', ToastColor.Success);
       });
 
       it('should form after success request', () => {

--- a/src/app/pages/private/profile/change-password/change-password.page.ts
+++ b/src/app/pages/private/profile/change-password/change-password.page.ts
@@ -2,7 +2,6 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject } from '@
 import { FormControl, NonNullableFormBuilder, ReactiveFormsModule, ValidationErrors, Validators } from '@angular/forms';
 import { BackButtonComponent } from '@components/back-button/back-button.component';
 import { PasswordComponent } from '@components/password/password.component';
-import { AppConstants } from '@constants/app.constants';
 import { RegularExpressions } from '@constants/regular-expressions';
 import { UsersApiService } from '@features/users/services/users-api.service';
 import { ChangePasswordBody } from '@features/users/users.models';
@@ -15,12 +14,12 @@ import {
   IonItem,
   IonList,
   IonToolbar,
-  ToastOptions,
 } from '@ionic/angular/standalone';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { LoaderService } from '@services/loader/loader.service';
+import { ToastColor } from '@services/toast/toast.models';
 import { ToastService } from '@services/toast/toast.service';
-import { Observable, switchMap, take } from 'rxjs';
+import { switchMap, take } from 'rxjs';
 import { AppValidators } from 'src/app/validators/app.validators';
 
 import { ChangePasswordForm } from './change-password.models';
@@ -94,25 +93,16 @@ export default class ChangePasswordPage {
     this.loaderService
       .showUntilCompleted$(request$)
       .pipe(
-        switchMap(() => this.openSuccessToast$()),
+        switchMap(() => {
+          const message = this.translateService.instant('change_password.toast');
+
+          return this.toastService.open$(message, ToastColor.Success);
+        }),
         take(1),
       )
       .subscribe(() => {
         this.changePasswordForm.reset();
         this.cdr.markForCheck();
       });
-  }
-
-  private openSuccessToast$(): Observable<HTMLIonToastElement> {
-    const toastOptions: ToastOptions = {
-      message: this.translateService.instant('change_password.toast'),
-      duration: AppConstants.toastDuration,
-      cssClass: 'app-toast',
-      position: 'bottom',
-      color: 'success',
-      buttons: [{ icon: 'close-outline', role: 'cancel' }],
-    };
-
-    return this.toastService.open$(toastOptions);
   }
 }

--- a/src/app/pages/private/profile/profile.page.spec.ts
+++ b/src/app/pages/private/profile/profile.page.spec.ts
@@ -1,6 +1,5 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Router } from '@angular/router';
-import { AppConstants } from '@constants/app.constants';
 import { AuthFacadeService } from '@features/auth/services/auth-facade/auth-facade.service';
 import { UsersApiService } from '@features/users/services/users-api.service';
 import { UsersStoreMock } from '@features/users/store/users.state.testing';
@@ -10,6 +9,7 @@ import { AlertEventRole } from '@models/app.models';
 import { TranslateService } from '@ngx-translate/core';
 import { classWithProviders } from '@ngx-unit-test/inject-mocks';
 import { AlertService } from '@services/alert/alert.service';
+import { ToastColor } from '@services/toast/toast.models';
 import { ToastService } from '@services/toast/toast.service';
 import { MockProxy, mock } from 'jest-mock-extended';
 import { of, throwError } from 'rxjs';
@@ -258,17 +258,8 @@ describe(ProfilePage.name, () => {
   });
 
   it('should open toast in case of successful request', () => {
-    const expectedToastConfig = {
-      message: 'profile.verify_email_toast',
-      duration: AppConstants.toastDuration,
-      cssClass: 'app-toast',
-      position: 'bottom',
-      color: 'success',
-      buttons: [{ icon: 'close-outline', role: 'cancel' }],
-    };
-
     component.requestEmailVerification(mock<MouseEvent>());
 
-    expect(toastServiceMock.open$).toHaveBeenCalledWith(expectedToastConfig);
+    expect(toastServiceMock.open$).toHaveBeenCalledWith('profile.verify_email_toast', ToastColor.Success);
   });
 });

--- a/src/app/pages/private/profile/profile.page.ts
+++ b/src/app/pages/private/profile/profile.page.ts
@@ -22,12 +22,12 @@ import {
   IonTabButton,
   IonText,
   IonToolbar,
-  ToastOptions,
 } from '@ionic/angular/standalone';
 import { AlertEventRole } from '@models/app.models';
 import { OverlayEventDetail } from '@models/ionic.models';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { AlertService } from '@services/alert/alert.service';
+import { ToastColor } from '@services/toast/toast.models';
 import { ToastService } from '@services/toast/toast.service';
 import { addIcons } from 'ionicons';
 import { createOutline, logOutOutline } from 'ionicons/icons';
@@ -114,16 +114,11 @@ export default class ProfilePage {
       .resendVerificationEmail$()
       .pipe(
         switchMap(() => {
-          const toastOptions: ToastOptions = {
-            message: this.translateService.instant('profile.verify_email_toast', { email: this.userData()?.email }),
-            duration: AppConstants.toastDuration,
-            cssClass: 'app-toast',
-            position: 'bottom',
-            color: 'success',
-            buttons: [{ icon: 'close-outline', role: 'cancel' }],
-          };
+          const message = this.translateService.instant('profile.verify_email_toast', {
+            email: this.userData()?.email,
+          });
 
-          return this.toastService.open$(toastOptions);
+          return this.toastService.open$(message, ToastColor.Success);
         }),
         take(1),
       )

--- a/src/app/pages/public/forgot-password/forgot-password.page.spec.ts
+++ b/src/app/pages/public/forgot-password/forgot-password.page.spec.ts
@@ -1,8 +1,8 @@
-import { AppConstants } from '@constants/app.constants';
 import { UsersApiService } from '@features/users/services/users-api.service';
 import { GenericApiResponse } from '@models/api.models';
 import { TranslateService } from '@ngx-translate/core';
 import { classWithProviders } from '@ngx-unit-test/inject-mocks';
+import { ToastColor } from '@services/toast/toast.models';
 import { ToastService } from '@services/toast/toast.service';
 import { MockProxy, mock } from 'jest-mock-extended';
 import { of } from 'rxjs';
@@ -20,10 +20,10 @@ describe('ResetPasswordComponent', () => {
     usersApiServiceMock.requestPasswordReset$.mockReturnValue(of({} as GenericApiResponse));
 
     toastServiceMock = mock<ToastService>();
-    toastServiceMock.openWithListener$.mockReturnValue(of({} as any));
+    toastServiceMock.open$.mockReturnValue(of({} as any));
 
     translateServiceMock = mock<TranslateService>();
-    translateServiceMock.get.mockReturnValue(of('message'));
+    translateServiceMock.instant.mockImplementation(key => key);
 
     component = classWithProviders({
       token: ForgotPasswordComponent,
@@ -77,23 +77,14 @@ describe('ResetPasswordComponent', () => {
       component.forgotPasswordControl.setValue('email@gg.gg');
       component.submitForgotPassword();
 
-      expect(translateServiceMock.get).toHaveBeenCalledWith('forgot_password.toast', { email: 'email@gg.gg' });
+      expect(translateServiceMock.instant).toHaveBeenCalledWith('forgot_password.toast', { email: 'email@gg.gg' });
     });
 
-    it('should open toast in case of success request', () => {
-      const expectedToastConfig = {
-        message: 'message',
-        duration: AppConstants.toastDuration,
-        cssClass: 'app-toast',
-        position: 'bottom',
-        color: 'success',
-        buttons: [{ icon: 'close-outline', role: 'cancel' }],
-      };
-
+    it('shouldopen toast in case of success', () => {
       component.forgotPasswordControl.setValue('email@gg.gg');
       component.submitForgotPassword();
 
-      expect(toastServiceMock.openWithListener$).toHaveBeenCalledWith(expectedToastConfig);
+      expect(toastServiceMock.open$).toHaveBeenCalledWith('forgot_password.toast', ToastColor.Success);
     });
   });
 });

--- a/src/app/pages/public/forgot-password/forgot-password.page.ts
+++ b/src/app/pages/public/forgot-password/forgot-password.page.ts
@@ -2,14 +2,13 @@ import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { FormControl, ReactiveFormsModule, ValidationErrors, Validators } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { PublicHeaderComponent } from '@components/public-header/public-header.component';
-import { AppConstants } from '@constants/app.constants';
 import { RegularExpressions } from '@constants/regular-expressions';
 import { UsersApiService } from '@features/users/services/users-api.service';
-import { IonButton, IonContent, IonInput, IonItem, IonList, ToastOptions } from '@ionic/angular/standalone';
-import { OverlayEventDetail } from '@models/ionic.models';
+import { IonButton, IonContent, IonInput, IonItem, IonList } from '@ionic/angular/standalone';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { ToastColor } from '@services/toast/toast.models';
 import { ToastService } from '@services/toast/toast.service';
-import { Observable, switchMap, take } from 'rxjs';
+import { switchMap, take } from 'rxjs';
 
 @Component({
   standalone: true,
@@ -50,23 +49,13 @@ export default class ForgotPasswordComponent {
     this.usersApiService
       .requestPasswordReset$(email)
       .pipe(
-        switchMap(() => this.translateService.get('forgot_password.toast', { email })),
-        switchMap((message: string) => this.openToast$(message)),
+        switchMap(() => {
+          const message = this.translateService.instant('forgot_password.toast', { email });
+
+          return this.toastService.open$(message, ToastColor.Success);
+        }),
         take(1),
       )
       .subscribe();
-  }
-
-  private openToast$(message: string): Observable<OverlayEventDetail<void>> {
-    const toastOptions: ToastOptions = {
-      message,
-      duration: AppConstants.toastDuration,
-      cssClass: 'app-toast',
-      position: 'bottom',
-      color: 'success',
-      buttons: [{ icon: 'close-outline', role: 'cancel' }],
-    };
-
-    return this.toastService.openWithListener$(toastOptions);
   }
 }

--- a/src/app/pages/public/reset-password/reset-password.page.spec.ts
+++ b/src/app/pages/public/reset-password/reset-password.page.spec.ts
@@ -1,10 +1,10 @@
 import { signal } from '@angular/core';
 import { FormControl, FormGroup, NonNullableFormBuilder } from '@angular/forms';
-import { AppConstants } from '@constants/app.constants';
 import { UsersApiService } from '@features/users/services/users-api.service';
 import { GenericApiResponse } from '@models/api.models';
 import { TranslateService } from '@ngx-translate/core';
 import { classWithProviders } from '@ngx-unit-test/inject-mocks';
+import { ToastColor } from '@services/toast/toast.models';
 import { ToastService } from '@services/toast/toast.service';
 import { MockProxy, mock } from 'jest-mock-extended';
 import { of } from 'rxjs';
@@ -23,10 +23,10 @@ describe(ResetPasswordPage.name, () => {
     usersApiServiceMock.verifyPasswordReset$.mockReturnValue(of({} as GenericApiResponse));
 
     toastServiceMock = mock<ToastService>();
-    toastServiceMock.openWithListener$.mockReturnValue(of({} as any));
+    toastServiceMock.open$.mockReturnValue(of({} as any));
 
     translateServiceMock = mock<TranslateService>();
-    translateServiceMock.get.mockReturnValue(of('message'));
+    translateServiceMock.instant.mockImplementation(key => key);
 
     formBuilderMock = mock<NonNullableFormBuilder>();
     formBuilderMock.group.mockReturnValue(
@@ -114,22 +114,13 @@ describe(ResetPasswordPage.name, () => {
       it('should trigger translate toast message in case of success request', () => {
         component.submitResetPassword();
 
-        expect(translateServiceMock.get).toHaveBeenCalledWith('reset_password.toast');
+        expect(translateServiceMock.instant).toHaveBeenCalledWith('reset_password.toast');
       });
 
-      it('should open toast in case of success request', () => {
-        const expectedToastConfig = {
-          message: 'message',
-          duration: AppConstants.toastDuration,
-          cssClass: 'app-toast',
-          position: 'bottom',
-          color: 'success',
-          buttons: [{ icon: 'close-outline', role: 'cancel' }],
-        };
-
+      it('should should open toast in case of success request', () => {
         component.submitResetPassword();
 
-        expect(toastServiceMock.openWithListener$).toHaveBeenCalledWith(expectedToastConfig);
+        expect(toastServiceMock.open$).toHaveBeenCalledWith('reset_password.toast', ToastColor.Success);
       });
     });
   });

--- a/src/app/pages/public/reset-password/reset-password.page.ts
+++ b/src/app/pages/public/reset-password/reset-password.page.ts
@@ -3,14 +3,13 @@ import { FormControl, NonNullableFormBuilder, ReactiveFormsModule, ValidationErr
 import { RouterLink } from '@angular/router';
 import { PasswordComponent } from '@components/password/password.component';
 import { PublicHeaderComponent } from '@components/public-header/public-header.component';
-import { AppConstants } from '@constants/app.constants';
 import { RegularExpressions } from '@constants/regular-expressions';
 import { UsersApiService } from '@features/users/services/users-api.service';
-import { IonButton, IonContent, IonItem, IonList, IonText, ToastOptions } from '@ionic/angular/standalone';
-import { OverlayEventDetail } from '@models/ionic.models';
+import { IonButton, IonContent, IonItem, IonList, IonText } from '@ionic/angular/standalone';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { ToastColor } from '@services/toast/toast.models';
 import { ToastService } from '@services/toast/toast.service';
-import { Observable, switchMap, take } from 'rxjs';
+import { switchMap, take } from 'rxjs';
 import { AppValidators } from 'src/app/validators/app.validators';
 
 import { ResetPasswordForm } from './reset-password.models';
@@ -77,23 +76,13 @@ export default class ResetPasswordPage {
     this.usersApiService
       .verifyPasswordReset$(body)
       .pipe(
-        switchMap(() => this.translateService.get('reset_password.toast')),
-        switchMap((message: string) => this.openToast$(message)),
+        switchMap(() => {
+          const message = this.translateService.instant('reset_password.toast');
+
+          return this.toastService.open$(message, ToastColor.Success);
+        }),
         take(1),
       )
       .subscribe();
-  }
-
-  private openToast$(message: string): Observable<OverlayEventDetail<void>> {
-    const toastOptions: ToastOptions = {
-      message,
-      duration: AppConstants.toastDuration,
-      cssClass: 'app-toast',
-      position: 'bottom',
-      color: 'success',
-      buttons: [{ icon: 'close-outline', role: 'cancel' }],
-    };
-
-    return this.toastService.openWithListener$(toastOptions);
   }
 }

--- a/src/app/services/toast/toast.models.ts
+++ b/src/app/services/toast/toast.models.ts
@@ -1,0 +1,4 @@
+export enum ToastColor {
+  Danger = 'danger',
+  Success = 'success',
+}

--- a/src/app/services/toast/toast.service.spec.ts
+++ b/src/app/services/toast/toast.service.spec.ts
@@ -4,6 +4,7 @@ import { classWithProviders } from '@ngx-unit-test/inject-mocks';
 import { MockProxy, mock } from 'jest-mock-extended';
 import { of, take } from 'rxjs';
 
+import { ToastColor } from './toast.models';
 import { ToastService } from './toast.service';
 
 describe(ToastService.name, () => {
@@ -26,9 +27,18 @@ describe(ToastService.name, () => {
 
   describe('open$', () => {
     it('should trigger "create" method with target options', () => {
-      service.open$({}).pipe(take(1)).subscribe();
+      const expectedToastConfig = {
+        duration: 3000,
+        cssClass: 'app-toast',
+        position: 'bottom',
+        message: 'message',
+        color: ToastColor.Success,
+        buttons: [{ icon: 'close-outline', role: 'cancel' }],
+      };
 
-      expect(toastControllerMock.create).toHaveBeenCalledWith({});
+      service.open$('message', ToastColor.Success).pipe(take(1)).subscribe();
+
+      expect(toastControllerMock.create).toHaveBeenCalledWith(expectedToastConfig);
     });
 
     it('should trigger "present" method to display toast', fakeAsync(() => {
@@ -37,29 +47,10 @@ describe(ToastService.name, () => {
         present: presentSpy,
       } as any);
 
-      service.open$({}).pipe(take(1)).subscribe();
+      service.open$('message', ToastColor.Success).pipe(take(1)).subscribe();
       tick();
 
       expect(presentSpy).toHaveBeenCalledTimes(1);
     }));
-  });
-
-  describe('openWithListener$', () => {
-    it('should trigger "open" method with target options', () => {
-      const spy = jest.spyOn(service, 'open$');
-
-      service.openWithListener$({}).pipe(take(1)).subscribe();
-
-      expect(spy).toHaveBeenCalledWith({});
-    });
-
-    it('should trigger "onDidDismiss" method to know when toaster closed', () => {
-      const didDismissSpy = jest.fn();
-      jest.spyOn(service, 'open$').mockReturnValue(of({ onDidDismiss: didDismissSpy } as any));
-
-      service.openWithListener$({}).pipe(take(1)).subscribe();
-
-      expect(didDismissSpy).toHaveBeenCalledTimes(1);
-    });
   });
 });

--- a/src/app/services/toast/toast.service.ts
+++ b/src/app/services/toast/toast.service.ts
@@ -1,21 +1,25 @@
 import { Injectable, inject } from '@angular/core';
 import { ToastController, ToastOptions } from '@ionic/angular/standalone';
-import { OverlayEventDetail } from '@models/ionic.models';
-import { Observable, from, switchMap, tap } from 'rxjs';
+import { Observable, from, tap } from 'rxjs';
+
+import { ToastColor } from './toast.models';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ToastService {
+  private readonly baseToastConfig: ToastOptions = {
+    duration: 3000,
+    cssClass: 'app-toast',
+    position: 'bottom',
+    buttons: [{ icon: 'close-outline', role: 'cancel' }],
+  };
+
   private readonly toastControl = inject(ToastController);
 
-  open$(options: ToastOptions): Observable<HTMLIonToastElement> {
-    return from(this.toastControl.create(options)).pipe(
+  open$(message: string, color: ToastColor): Observable<HTMLIonToastElement> {
+    return from(this.toastControl.create({ ...this.baseToastConfig, message, color })).pipe(
       tap((toastElement: HTMLIonToastElement) => toastElement.present()),
     );
-  }
-
-  openWithListener$<T>(options: ToastOptions): Observable<OverlayEventDetail<T>> {
-    return this.open$(options).pipe(switchMap((toastCtrl: HTMLIonToastElement) => toastCtrl.onDidDismiss()));
   }
 }


### PR DESCRIPTION

* Removed 'openWithListener$' method, since it is obsolete and can be fully replaced with 'open$';

* Created anum for toast color;

* Removed app constant for toast duration, because it is used only in one place now;